### PR TITLE
added: ignore 'archupgrade-go' binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+archupgrade-go
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
This gets generated when running 'go build'.